### PR TITLE
added code to handle the break command sent by GRBL once serial conne…

### DIFF
--- a/src/machineservice.js
+++ b/src/machineservice.js
@@ -230,8 +230,12 @@ app.service('machineService', function($rootScope, $timeout, warningService) {
 
   // Log errors
   chrome.serial.onReceiveError.addListener(function(info) {
+    if (info.error === "break") {
+      chrome.serial.setPaused(info.connectionId, false, function() {});    
+    } else {
     warningService.warn("connection", "error with serial communication: " + info.error);
     $rootScope.$apply();
+    }
   });
 
   /**


### PR DESCRIPTION
GRBL firmware seems to issue a serial break once the connection is established.  This would leave the chrome serial service in a paused state.  By simply unpausing the serial service, grbl firmware continues to work as expected.