### PR TITLE
Add support for $-scodes

### DIFF
--- a/src/gcode_util.js
+++ b/src/gcode_util.js
@@ -102,7 +102,7 @@ function extractCommandSequence(text) {
     }
 
     // Check for the start of a new command.
-    if (c == 'G' || c == 'M') {
+    if (c == 'G' || c == 'M' || c == '$') {
       addSequence();
     }
 
@@ -262,6 +262,9 @@ function analyzeGcode(gcode) {
       }
     } else if (cType == "M") {
       // M codes can safely be ignored.
+      continue;
+    } else if (cType == "$") {
+      // Setting variables can safely be ignored.
       continue;
     } else {
       msg = "unknown gcode command: " + parts[0];

--- a/src/loadfile.js
+++ b/src/loadfile.js
@@ -284,6 +284,9 @@ app.controller('loadFileCtrl', function($scope, $state, hotkeys,
           msg = "unimplemented gcode command: " + parts[0];
           warnings[msg] = (warnings[msg] || 0) + 1;
         }
+      } else if (cType == "$") {
+        // Set variables (non-standard?)
+        continue;
       } else {
         msg = "unknown gcode command: " + parts[0];
         warnings[msg] = (warnings[msg] || 0) + 1;


### PR DESCRIPTION
GRBL uses these for setting configuration, such as acceleration.